### PR TITLE
Version 0.3.6 release: change groupId to io.malcolmgreaves

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 
-organization in ThisBuild := "com.gonitro"
+organization in ThisBuild := "io.malcolmgreaves"
 
 scalaVersion in ThisBuild := scala212v
 

--- a/codegen/src/sbt-test/simple/e2e/build.sbt
+++ b/codegen/src/sbt-test/simple/e2e/build.sbt
@@ -10,9 +10,9 @@ version      := ""
 
 // dependencies & resolvers
 libraryDependencies ++= Seq(
-  "com.gonitro"   %% "avro-codegen-runtime" % sys.props("project.version"),
-  "com.chuusai"   %% "shapeless"            % "2.3.2",
-  "org.scalatest" %% "scalatest"            % "3.0.1" % Test
+  "io.malcolmgreaves" %% "avro-codegen-runtime" % sys.props("project.version"),
+  "com.chuusai"       %% "shapeless"            % "2.3.2",
+  "org.scalatest"     %% "scalatest"            % "3.0.1" % Test
 )
 resolvers ++= Seq(
   "Sonatype Releases"  at "https://oss.sonatype.org/content/repositories/releases/",

--- a/codegen/src/sbt-test/simple/e2e/project/avrocodegen.sbt
+++ b/codegen/src/sbt-test/simple/e2e/project/avrocodegen.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.gonitro" % "avro-codegen-compiler" % sys.props("project.version"))
+addSbtPlugin("io.malcolmgreaves" % "avro-codegen-compiler" % sys.props("project.version"))
 addSbtPlugin("com.gonitro" % "sbt-dev-settings" % "0.2.1")

--- a/project/SharedForBuild.scala
+++ b/project/SharedForBuild.scala
@@ -48,7 +48,7 @@ object SharedForBuild extends Build {
 
   lazy val pubSettings =
     Publish.settings(
-      Repository.github("Nitro", "avro-codegen"),
+      Repository.github("malcolmgreaves", "avro-codegen"),
       pluginDevelopers,
       ArtifactInfo.sonatype(semver),
       License.apache20

--- a/project/SharedForBuild.scala
+++ b/project/SharedForBuild.scala
@@ -10,7 +10,7 @@ object SharedForBuild extends Build {
   import com.nitro.build._
   import PublishHelpers._
 
-  lazy val semver = SemanticVersion(0, 3, 5, isSnapshot = false)
+  lazy val semver = SemanticVersion(0, 3, 6, isSnapshot = false)
 
   lazy val apacheAvroDep = "org.apache.avro" % "avro" % "1.8.1"
 


### PR DESCRIPTION
Release version 0.3.6 for Scala 2.12. Includes change of the groupId (`organization` sbt key) to io.malcolmgreaves, reflecting new project stewardship.