### PR TITLE
Avro 1.9 compatibility

### DIFF
--- a/codegen/src/main/scala/com/nitro/scalaAvro/codegen/AvroGenerator.scala
+++ b/codegen/src/main/scala/com/nitro/scalaAvro/codegen/AvroGenerator.scala
@@ -204,7 +204,7 @@ class AvroGenerator(val params: AvroGeneratorParams = AvroGeneratorParams()) ext
 
   def generateFromMutable(enum: AvroEnum)(printer: FunctionalPrinter): FunctionalPrinter = {
     printer
-      .add(s"def fromMutable(generic: ${Types.GenericEnumInterface}): ${enum.getName.asSymbol} = generic.toString match {")
+      .add(s"def fromMutable(generic: ${Types.GenericEnumInterface}[${Types.GenericEnumBase}]): ${enum.getName.asSymbol} = generic.toString match {")
       .print(enum.getValues) {
         case (v, p) => p.add(s"""  case "${v.name}" => ${v.name.asSymbol}""")
       }.add("}")
@@ -367,7 +367,7 @@ trait AvroExpressions {
     }).orElse(schema.asMap.map { map => (s: String) =>
       s"""scala.collection.immutable.Map() ++ scala.collection.JavaConversions.mapAsScalaMap($s.asInstanceOf[java.util.HashMap[${Types.Utf8}, Any]]).map{ case (_k,_v) => (${stringConverter("_k")}, ${fromMutable(map.valueType)("_v")})}"""
     }).orElse(schema.asEnum.map { enum => (s: String) =>
-      s"${enum.getName.asSymbol}.fromMutable($s.asInstanceOf[${Types.GenericEnumInterface}])"
+      s"${enum.getName.asSymbol}.fromMutable($s.asInstanceOf[${Types.GenericEnumInterface}[${Types.GenericEnumBase}]])"
     }).orElse(schema.asRecord.map { record => (s: String) =>
       s"${record.fullScalaTypeName}.fromMutable($s.asInstanceOf[${Types.GenericRecordInterface}])"
     }).orElse(schema.asString.map { string => (s: String) =>

--- a/project/SharedForBuild.scala
+++ b/project/SharedForBuild.scala
@@ -10,9 +10,9 @@ object SharedForBuild extends Build {
   import com.nitro.build._
   import PublishHelpers._
 
-  lazy val semver = SemanticVersion(0, 3, 7, isSnapshot = false)
+  lazy val semver = SemanticVersion(0, 4, 0, isSnapshot = true)
 
-  lazy val apacheAvroDep = "org.apache.avro" % "avro" % "1.8.1"
+  lazy val apacheAvroDep = "org.apache.avro" % "avro" % "1.9.2"
 
   private[this] def githubUrl(id: String) =
     new URL("http", "github.com", s"/$id")
@@ -23,7 +23,7 @@ object SharedForBuild extends Build {
     Developer("ebiggs",         "Eric Biggs",      "ebiggs@gmail.com",          new URL("http", "ebiggs.com", ""))
   )
 
-  lazy val scala212v = "2.12.3"
+  lazy val scala212v = "2.12.6"
   lazy val scala211v = "2.11.11"
   lazy val scala210v = "2.10.6"
 

--- a/project/SharedForBuild.scala
+++ b/project/SharedForBuild.scala
@@ -10,7 +10,7 @@ object SharedForBuild extends Build {
   import com.nitro.build._
   import PublishHelpers._
 
-  lazy val semver = SemanticVersion(0, 4, 0, isSnapshot = true)
+  lazy val semver = SemanticVersion(0, 4, 0, isSnapshot = false)
 
   lazy val apacheAvroDep = "org.apache.avro" % "avro" % "1.9.2"
 
@@ -23,6 +23,7 @@ object SharedForBuild extends Build {
     Developer("ebiggs",         "Eric Biggs",      "ebiggs@gmail.com",          new URL("http", "ebiggs.com", ""))
   )
 
+  lazy val scala213v = "2.13.2"
   lazy val scala212v = "2.12.6"
   lazy val scala211v = "2.11.11"
   lazy val scala210v = "2.10.6"
@@ -37,7 +38,7 @@ object SharedForBuild extends Build {
         fatalWarnings = false,
         logImplicits = false,
         optimize = true,
-        crossCompile = Seq(scala212v, scala211v, scala210v),
+        crossCompile = Seq(scala213v, scala212v, scala211v, scala210v),
         inlineWarn = true,
         genBBackend = false
       )

--- a/runtime/src/main/scala/com/nitro/scalaAvro/runtime/GeneratedMessageCompanion.scala
+++ b/runtime/src/main/scala/com/nitro/scalaAvro/runtime/GeneratedMessageCompanion.scala
@@ -13,7 +13,7 @@ trait GeneratedEnum {
 trait GeneratedEnumCompanion[A <: GeneratedEnum] {
   type ValueType = A
   def fromValue(id: Int): A
-  def fromMutable(generic: org.apache.avro.generic.GenericEnumSymbol): A
+  def fromMutable(generic: org.apache.avro.generic.GenericEnumSymbol[org.apache.avro.generic.GenericData.EnumSymbol]): A
   def values: Seq[A]
   def _arbitrary: Gen[A]
 }


### PR DESCRIPTION
The 1.9 release of avro modified GenericEnumSymbol to take a type parameter, causing the generated classes to not compile.

This was the breaking change in avro:

https://github.com/apache/avro/commit/4a3609cd854e9ef5bdda5b43e188a3309a93aef9

Thinking this should bump the minor version.