### PR TITLE
Use openjdk instead of oracle: fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 jdk:
-  - oraclejdk8
+  - openjdk8
 scala: 2.12.3
 script: 
   - sbt clean update compile test runtime/publishLocal codegen/scripted


### PR DESCRIPTION
Oracle JDK 8 is no longer available using the normal means of provisioning builds on Travis. Change to use OpenJDK 8: https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766